### PR TITLE
refactor: enable hotswapping of omdb api key

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,12 +27,21 @@
               '';
               languages = {
                 go.enable = true;
+                javascript = {
+                  enable = true;
+                  npm = {
+                    enable = true;
+                    install.enable = true;
+                  };
+                };
                 nix.enable = true;
+                typescript.enable = true;
               };
               packages = with pkgs; [
                 commitizen
                 gnumake
                 golangci-lint
+                wget
               ];
               pre-commit = {
                 default_stages = ["pre-push"];

--- a/internal/server/handlers/register.go
+++ b/internal/server/handlers/register.go
@@ -15,7 +15,7 @@ import (
 )
 
 type registerRequest struct {
-	RawName string `json:"name"`
+	RawName  string `json:"name"`
 	RawEmail string `json:"email"`
 }
 

--- a/internal/services/omdb/service.go
+++ b/internal/services/omdb/service.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"movie-matcher/internal/duration"
@@ -115,15 +114,8 @@ func movieFromResult(res result) Movie {
 }
 
 var (
-	apiKey string
-	once   sync.Once
 	client = &apiClient{
 		apiKey: func() string {
-			once.Do(func() {
-				apiKey = os.Getenv("OMDB_API_KEY")
-			})
-
-			return apiKey
-		},
-	}
+			return os.Getenv("OMDB_API_KEY")
+		}}
 )


### PR DESCRIPTION
<!--
Before opening a pull request, please ensure you've done the following:

- 👷‍♀️ Created a small PR.
- 📝 Used a descriptive title.
- ✅ Provided tests for your changes (if applicable).
- 📗 Updated relevant documentation.

Please be patient! We will review your pull request as soon as possible.
-->

# Description
<!--
What does this change accomplish? Why did you make this change?
-->
The OMDb API key should be read from the env var as need, rather than on server startup. This allows us to swap out the API key without restarting the server


# Related Issues
<!--
For pull requests that close an issue, please include them below.
We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
Example: "Closes #10"
-->
Closes #64 